### PR TITLE
Test PR: what version of PHPunit is each test running?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
     - sed -i "s/yourpasswordhere//" wp-tests-config.php
     - mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
     - cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - phpunit --version
 
 script: phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,10 @@ before_script:
     - sed -i "s/yourpasswordhere//" wp-tests-config.php
     - mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
     - cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
-    - phpunit --version
 
-script: phpunit
+script:
+    - phpunit
+    - phpunit --version
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ php:
 
 # WordPress versions
 env:
-    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 # PHP Versions
 php:
     - 5.6
+    - 7.0
     - 7.1
     - 7.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,54 @@
-language: php
-php:
-- 5.3
-- 5.4
-- 5.5
-- 5.6
+# Travis CI Configuration File
+
+# Use Travis CI container-based infrastructure
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
+
+# Tell Travis CI we're using PHP
+language: php
+
+# PHP Versions
+php:
+    - 5.6
+    - 7.1
+    - 7.2
+
+# WordPress versions
 env:
-- WP_VERSION=4.1.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+
 branches:
-  only:
-  - master
+    only:
+        - master
+
 before_script:
-- export SLUG=$(basename $(pwd))
-- svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
-- cd ..
-- mv $SLUG "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
-- cd $WP_CORE_DIR
-- mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-- cp wp-tests-config-sample.php wp-tests-config.php
-- sed -i "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/src/':" wp-tests-config.php
-- sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-- sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-- sed -i "s/yourpasswordhere//" wp-tests-config.php
-- mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
-- cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - export SLUG=$(basename $(pwd))
+    - svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
+    - cd ..
+    - mv $SLUG "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - cd $WP_CORE_DIR
+    - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    - cp wp-tests-config-sample.php wp-tests-config.php
+    - sed -i "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/src/':" wp-tests-config.php
+    - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    - sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    - sed -i "s/yourpasswordhere//" wp-tests-config.php
+    - mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
+    - cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+
 script: phpunit
+
 notifications:
   slack:
     secure: Iji+RK3PdJbN1/aMBEnLxJ+D1LJCd9wOe7ka+y5TtFq8EMZXy8S/m8IxS+mqSvZUOhGwfgBXL9jsyCPVkqpkNNwY/34QDC8iQQU8e10TpVuD5YUfSOo6Fa/RtQik1gYUFbrxt9OCt4CaMEcyDdVTNb5A/cIoisaqk5xmCeXSvJc=

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -75,12 +75,12 @@ function pmp_client_id_input() {
  * @since 0.1
  */
 function pmp_client_secret_input() {
-	$options = get_option('pmp_settings');
+	$options = get_option( 'pmp_settings' );
 
-	if (empty($options['pmp_client_secret'])) { ?>
-		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
-	<?php } else { ?>
+	if ( ! empty( $options ) && ! empty( $options['pmp_client_secret'] ) ) { ?>
 		<a href="#" id="pmp_client_secret_reset">Change client secret</a>
+	<?php } else { ?>
+		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
 	<?php }
 }
 /**

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -100,7 +100,10 @@ class TestFunctions extends WP_UnitTestCase {
 	function test_pmp_verify_settings() {
 		// Since we're setting the pmp_settings in bootstrap.php, this
 		// should return true
-		$this->assertTrue(pmp_verify_settings());
+		$this->assertTrue(
+			pmp_verify_settings(),
+			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
+		);
 	}
 
 	function test_pmp_on_post_status_transition() {

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -87,7 +87,7 @@ class TestFunctions extends WP_UnitTestCase {
 
 	function test_pmp_media_sideload_image() {
 		$new_post = $this->factory->post->create();
-		$url = 'http://publicmediaplatform.org/wp-content/uploads/logo1.png';
+		$url = 'http://blog.apps.npr.org/img/nprlogo.gif';
 		$desc = 'Test description';
 
 		$image_id = pmp_media_sideload_image($url, $new_post, $desc);
@@ -173,7 +173,7 @@ class TestFunctions extends WP_UnitTestCase {
 
 	function test_pmp_enclosures_for_media() {
 		$new_post = $this->factory->post->create();
-		$url = 'http://publicmediaplatform.org/wp-content/uploads/logo1.png';
+		$url = 'http://blog.apps.npr.org/img/nprlogo.gif';
 		$desc = 'Test description';
 
 		$image_id = pmp_media_sideload_image($url, $new_post, $desc);

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -80,8 +80,35 @@ class TestSettings extends WP_UnitTestCase {
 		pmp_client_id_input();
 	}
 
-	function test_pmp_client_secret_input() {
+	/**
+	 * Same as test_pmp_client_secret_input_option, but with an option saved
+	 *
+	 * @see test_pmp_client_secret_input_option
+	 * @see pmp_client_secret_input
+	 */
+	function test_pmp_client_secret_input_nooption() {
+		// save the PMP settings that exist at this point in the test
+		$preserve = get_option( 'pmp_settings' );
+
+		update_option( 'pmp_settings', null );
 		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
+		$this->expectOutputRegex($expect);
+		pmp_client_secret_input();
+
+		// reset
+		update_option( 'pmp_settings', $preserve );
+	}
+
+	/**
+	 * Expectation is valid in the case that `$options['pmp_client_secret']` is not empty
+	 * where `$options = get_option('pmp_settings')`.
+	 *
+	 * @see test_pmp_client_secret_input_nooption
+	 * @see pmp_client_secret_input
+	 */
+	function test_pmp_client_secret_input_option() {
+		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
+		$expect = '/' . $expect . '/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
 	}

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -81,7 +81,8 @@ class TestSettings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Same as test_pmp_client_secret_input_option, but with an option saved
+	 * Expectation is valid in the case that `$options['pmp_client_secret']` is not empty
+	 * or is unset, where `$options = get_option('pmp_settings')`.
 	 *
 	 * @see test_pmp_client_secret_input_option
 	 * @see pmp_client_secret_input
@@ -91,7 +92,8 @@ class TestSettings extends WP_UnitTestCase {
 		$preserve = get_option( 'pmp_settings' );
 
 		delete_option( 'pmp_settings' );
-		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
+		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
+		$expect = '/' . $expect . '/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
 
@@ -107,10 +109,19 @@ class TestSettings extends WP_UnitTestCase {
 	 * @see pmp_client_secret_input
 	 */
 	function test_pmp_client_secret_input_option() {
-		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
-		$expect = '/' . $expect . '/';
+		// save the PMP settings that exist at this point in the test
+		$preserve = get_option( 'pmp_settings' );
+
+		update_option( 'pmp_settings', array(
+			'pmp_client_secret' => 'test string',
+		) );
+
+		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
+
+		// reset
+		update_option( 'pmp_settings', $preserve );
 	}
 
 	function test_pmp_settings_validate() {

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -90,7 +90,7 @@ class TestSettings extends WP_UnitTestCase {
 		// save the PMP settings that exist at this point in the test
 		$preserve = get_option( 'pmp_settings' );
 
-		update_option( 'pmp_settings', null );
+		delete_option( 'pmp_settings' );
 		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();


### PR DESCRIPTION
https://github.com/INN/pmp-wordpress-plugin/issues/6

Hypothesis: there may be a mismatch between the version of php in use and the version of phpunit in use? https://phpunit.de/

Test: after this test runs:
- look at any php 5 build: should be phpunit 5
- look at the php 7.1 wordpress 4.7 build and see what phpunit version is in use: should be phpunit 5, 6, or 7
- look at any php 7.2 build: should be phpunit 6 or 7

If all those tests are true, then the hypothesis is disproven, and something else is going wrong in the build